### PR TITLE
Fix symbolic link for windows

### DIFF
--- a/src/api/tide.ts
+++ b/src/api/tide.ts
@@ -29,7 +29,9 @@ export default class Tide {
   public static async login(): Promise<LoginData> {
     let loginData = { isLogged: false }
     await this.runAndHandle(['login', '--json'], (data: string) => {
-      const parsedData = JSON.parse(data)
+      const jsonStart = data.indexOf('{')
+      const jsonString = data.slice(jsonStart)
+      const parsedData = JSON.parse(jsonString)
       loginData = { isLogged: parsedData['login_success'] }
       if (!loginData.isLogged) {
         UiController.showError('Login failed.')

--- a/webviews/common
+++ b/webviews/common
@@ -1,1 +1,0 @@
-../src/common

--- a/webviews/components/courses/CourseList.svelte
+++ b/webviews/components/courses/CourseList.svelte
@@ -5,7 +5,7 @@
    * @license MIT
    * @date 30.4.2024
    */
-  import { type Course, type CourseStatus } from '../../common/types'
+  import { type Course, type CourseStatus } from '../../../src/common/types'
   import CourseListItem from './CourseListItem.svelte'
 
   export let statusOfCourses: CourseStatus

--- a/webviews/components/courses/Courses.svelte
+++ b/webviews/components/courses/Courses.svelte
@@ -9,7 +9,7 @@
   import CourseList from './CourseList.svelte'
   import LoaderButton from '../common/LoaderButton.svelte'
   import { onMount } from 'svelte'
-  import { type Course, type LoginData, type WebviewMessage } from '../../common/types'
+  import { type Course, type LoginData, type WebviewMessage } from '../../../src/common/types'
 
   let downloadPath: string = ''
   let courses: Array<Course> = []

--- a/webviews/components/sidebar/Sidebar.svelte
+++ b/webviews/components/sidebar/Sidebar.svelte
@@ -7,7 +7,7 @@
    */
 
   import { onMount } from 'svelte'
-  import { type LoginData } from '../../common/types'
+  import { type LoginData } from '../../../src/common/types'
   let isLoggedIn = false
   let loginData: LoginData
 

--- a/webviews/components/taskPanel/TaskPanel.svelte
+++ b/webviews/components/taskPanel/TaskPanel.svelte
@@ -12,7 +12,7 @@
     type TaskPoints,
     type TimData,
     type WebviewMessage,
-  } from '../../common/types'
+  } from '../../../src/common/types'
   import PointsDisplay from './PointsDisplay.svelte'
 
   let timData: TimData

--- a/webviews/globals.d.ts
+++ b/webviews/globals.d.ts
@@ -1,5 +1,5 @@
 import * as _vscode from 'vscode'
-import { MessageType, type WebviewMessage } from './common/types'
+import { MessageType, type WebviewMessage } from '../src/common/types'
 
 declare global {
   const tsvscode: {


### PR DESCRIPTION
Removed src/common which is a symbolic link.

Updated following to reflect the removal of symbolic link:

webviews/components/courses/CourseList.svelte
webviews/components/courses/Courses.svelte
webviews/components/sidebar/Sidebar.svelte
webviews/components/taskPanel/TaskPanel.svelte
webviews/globals.d.ts